### PR TITLE
Split up patch to two as its version dependent and explicitly depend on cetmodules

### DIFF
--- a/dunedaq-spack-repo/packages/trace/install-exec.diff
+++ b/dunedaq-spack-repo/packages/trace/install-exec.diff
@@ -1,0 +1,12 @@
+diff --git a/src_utility/CMakeLists.txt b/src_utility/CMakeLists.txt
+index 42257e1..31c6dd3 100644
+--- a/src_utility/CMakeLists.txt
++++ b/src_utility/CMakeLists.txt
+@@ -12,6 +12,7 @@ else (${cetmodules_FOUND})
+     trace_cntl
+     PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
+             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++  install(TARGETS trace_cntl DESTINATION bin)
+ endif (${cetmodules_FOUND})
+ 
+ #install_source()

--- a/dunedaq-spack-repo/packages/trace/install-scripts.diff
+++ b/dunedaq-spack-repo/packages/trace/install-scripts.diff
@@ -15,15 +15,3 @@ index f4e18cb..c261183 100644
 +                   trace_functions.sh
 +          DESTINATION bin)
  endif (${cetmodules_FOUND})
-diff --git a/src_utility/CMakeLists.txt b/src_utility/CMakeLists.txt
-index 42257e1..31c6dd3 100644
---- a/src_utility/CMakeLists.txt
-+++ b/src_utility/CMakeLists.txt
-@@ -12,6 +12,7 @@ else (${cetmodules_FOUND})
-     trace_cntl
-     PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
-             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-+  install(TARGETS trace_cntl DESTINATION bin)
- endif (${cetmodules_FOUND})
- 
- #install_source()

--- a/dunedaq-spack-repo/packages/trace/package.py
+++ b/dunedaq-spack-repo/packages/trace/package.py
@@ -33,4 +33,7 @@ class Trace(CMakePackage):
     version('stable', branch='stable')
     version('3.15.09', commit='f429a6a8b52925c31678cab5643f67df16f06fd5')
 
-    patch('install-scripts.diff')
+    patch('install-exec.diff', when='3.15.09')
+    patch('install-scripts.diff', when='stable')
+
+    depends_on('cetmodules@1.01.01:', type='build')


### PR DESCRIPTION


This is needed for #5 for me to make these work:

```
$ spack install trace@3.15.09
$ spack install trace@stable
```

@philiprodrigues I wonder why the lack of `cetmodules` didn't trip up your builds.  Maybe you have some mixing of UPS + Spack environments?  Or, maybe building via `spack install appfwk` hides this missing dependency?