### PR TITLE
Fix daq-buildtools CMake handling in appfwk

### DIFF
--- a/dunedaq-spack-repo/packages/appfwk/fix-find-dqt.patch
+++ b/dunedaq-spack-repo/packages/appfwk/fix-find-dqt.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	2020-09-21 12:05:16.278511028 -0400
++++ b/CMakeLists.txt	2020-09-21 12:07:19.907327971 -0400
+@@ -2,6 +2,6 @@
+ project(appfwk VERSION 1.1.0)
+ 
+ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../daq-buildtools/cmake ${CMAKE_MODULE_PATH})
+-include(DAQ)
++find_package(daq-buildtools)
+ 
+ daq_setup_environment()

--- a/dunedaq-spack-repo/packages/appfwk/package.py
+++ b/dunedaq-spack-repo/packages/appfwk/package.py
@@ -36,6 +36,9 @@ class Appfwk(CMakePackage):
     version('1.1.0', sha256='3a88d45b5251748d0041fb7ad3df07c086d5acf3c27b1ca213887c3ad15bee98')
     version('1.0.0', sha256='2d61dd2d9b685351f840cf085606935960ab2e437ff10be14be1d67adeea0255')
 
+    # probably needed earlier than 1.1.0
+    patch("fix-find-dqt.patch", when="1.1.0")
+
     # FIXME: Add dependencies if required.
     depends_on('daq-buildtools@spack-build')
     depends_on('boost')

--- a/dunedaq-spack-repo/packages/trace/install-exec.diff
+++ b/dunedaq-spack-repo/packages/trace/install-exec.diff
@@ -1,0 +1,12 @@
+diff --git a/src_utility/CMakeLists.txt b/src_utility/CMakeLists.txt
+index 42257e1..31c6dd3 100644
+--- a/src_utility/CMakeLists.txt
++++ b/src_utility/CMakeLists.txt
+@@ -12,6 +12,7 @@ else (${cetmodules_FOUND})
+     trace_cntl
+     PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
+             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
++  install(TARGETS trace_cntl DESTINATION bin)
+ endif (${cetmodules_FOUND})
+ 
+ #install_source()

--- a/dunedaq-spack-repo/packages/trace/install-scripts.diff
+++ b/dunedaq-spack-repo/packages/trace/install-scripts.diff
@@ -15,15 +15,3 @@ index f4e18cb..c261183 100644
 +                   trace_functions.sh
 +          DESTINATION bin)
  endif (${cetmodules_FOUND})
-diff --git a/src_utility/CMakeLists.txt b/src_utility/CMakeLists.txt
-index 42257e1..31c6dd3 100644
---- a/src_utility/CMakeLists.txt
-+++ b/src_utility/CMakeLists.txt
-@@ -12,6 +12,7 @@ else (${cetmodules_FOUND})
-     trace_cntl
-     PUBLIC $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
-             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-+  install(TARGETS trace_cntl DESTINATION bin)
- endif (${cetmodules_FOUND})
- 
- #install_source()

--- a/dunedaq-spack-repo/packages/trace/package.py
+++ b/dunedaq-spack-repo/packages/trace/package.py
@@ -33,4 +33,7 @@ class Trace(CMakePackage):
     version('stable', branch='stable')
     version('3.15.09', commit='f429a6a8b52925c31678cab5643f67df16f06fd5')
 
-    patch('install-scripts.diff')
+    patch('install-exec.diff', when='3.15.09')
+    patch('install-scripts.diff', when='stable')
+
+    depends_on('cetmodules@1.01.01:', type='build')

--- a/dunedaq-spack-repo/packages/trace/package.py
+++ b/dunedaq-spack-repo/packages/trace/package.py
@@ -36,4 +36,4 @@ class Trace(CMakePackage):
     patch('install-exec.diff', when='3.15.09')
     patch('install-scripts.diff', when='stable')
 
-    depends_on('cetmodules@1.01.01:', type='build')
+    depends_on('cetmodules@1.01.01:', when='3.15.09', type='build')


### PR DESCRIPTION
In appfwk 1.1.0 we still had broken handling of daq-buildtools.  This adds a patch for Spack to provide to retroactively fix that.